### PR TITLE
[BVH] Uniform split via centroid binning 

### DIFF
--- a/Lunar/Camera/EditorCamera.h
+++ b/Lunar/Camera/EditorCamera.h
@@ -59,6 +59,8 @@ namespace Lunar {
 		glm::vec3 GetForwardDirection() const;
 		glm::quat GetOrientation() const;
 		inline glm::vec2 GetViewportSize() const { return glm::vec2(m_ViewportWidth, m_ViewportHeight); }
+		inline float GetFarClip() const  { return m_FarClip; }
+		inline float GetNearClip() const  { return m_NearClip; }
 
 
 	private:
@@ -78,16 +80,16 @@ namespace Lunar {
 		float ZoomSpeed() const;
 
 	private:
-		float m_FOV = 45.0f, m_AspectRatio = 1.778f, m_NearClip = 0.1f, m_FarClip = 1000.0f;
+		float m_FOV = 45.0f, m_AspectRatio = 1.778f, m_NearClip = 0.01f, m_FarClip = 100.0f;
 
 		glm::mat4 m_ViewMatrix;
-		glm::vec3 m_Position = { 0.0f, 0.0f, 0.0f };
+		glm::vec3 m_Position = { 4.0f, 4.0f, 8.0f };
 		glm::vec3 m_FocalPoint = { 0.0f, 0.0f, 0.0f };
 
 		glm::vec2 m_InitialMousePosition = { 0.0f, 0.0f };
 
 		float m_Distance = 10.0f;
-		float m_Pitch = 0.0f, m_Yaw = 0.0f;
+		float m_Pitch = 0.4f, m_Yaw = -0.4f;
 
 		float m_ViewportWidth = 1280, m_ViewportHeight = 720;
 	};

--- a/Lunar/Core/Application.cpp
+++ b/Lunar/Core/Application.cpp
@@ -106,9 +106,7 @@ namespace Lunar {
 			glfwTerminate();
 			assert(false && "glew initialization failed");
 		}
-		// TODO: remove later!
-		glEnable(GL_DEPTH_TEST); // 약간 야매 방식. depth buffer 없이 실시간 검사로 일단 테스트 (임시 방편)
-		glEnable(GL_CULL_FACE); //  enable backface culling
+
 		m_Window.BufferWidth = m_Specification.Width;
 		m_Window.BufferHeight = m_Specification.Height;
 		glViewport(0, 0, m_Window.BufferWidth, m_Window.BufferHeight); // Setup Viewport size (OpenGL functionality)

--- a/LunarApp/src/AABB/AABB.h
+++ b/LunarApp/src/AABB/AABB.h
@@ -256,6 +256,7 @@ private:
 	// Subdivide space
 	void __BuildBVH_TopDown()
 	{
+		LOG_INFO("Building BVH...    [total: {0}]", m_TotalTriangleCount);
 		m_Nodes.clear();
 		// to start, assign all triangles to root node.
 		m_Nodes.emplace_back( 0, m_Triangles.size() ); // (0) insert node at root
@@ -402,7 +403,6 @@ private:
 	void __Subdivide_recur(unsigned int parentNodeIdx)
 	{
 		AABBNode& node = m_Nodes[parentNodeIdx];
-		LOG_INFO("Building BVH...    [{0}/{1}]", node.m_TriangeCount, m_TotalTriangleCount);
 
 		// NOTE: find best split plane.
 		SplitEvaluationResult evaluationResult = __FindBestSplitPlane(node);

--- a/LunarApp/src/AABB/AABB.h
+++ b/LunarApp/src/AABB/AABB.h
@@ -256,7 +256,7 @@ private:
 	// Subdivide space
 	void __BuildBVH_TopDown()
 	{
-		LOG_INFO("Building BVH...    [total: {0}]", m_TotalTriangleCount);
+//		LOG_INFO("Building BVH...    [total: {0}]", m_TotalTriangleCount);
 		m_Nodes.clear();
 		// to start, assign all triangles to root node.
 		m_Nodes.emplace_back( 0, m_Triangles.size() ); // (0) insert node at root
@@ -656,7 +656,7 @@ private:
 	// 	     일단은 DFS로 함. 나중에 수정할 예정.
 	void __GenerateDebugMesh_recur(unsigned int node_idx, int depth)
 	{
-		LOG_INFO("Generating BVH DebugMesh...    [node:{0}/{1}]", node_idx, m_Nodes.size());
+		LOG_INFO("Generating BVH DebugMesh...    [node:{0}/{1} of total {2} triangles]", node_idx, m_Nodes.size(), m_TotalTriangleCount);
 		auto bbox = m_Nodes[node_idx].m_Bounds;
 		const auto ub = bbox.m_UpperBound;
 		const auto lb = bbox.m_LowerBound;

--- a/LunarApp/src/App.cpp
+++ b/LunarApp/src/App.cpp
@@ -260,8 +260,8 @@ public:
 		m_RasterizationFrameBuffer.Init(width, height); // Init Rasterization buffer
 
 	// 1. Create object
-		 m_Model.LoadModel("LunarApp/assets/teapot2.obj");
-//		m_Model.LoadModel("LunarApp/assets/bunny/bunny.obj");
+//		 m_Model.LoadModel("LunarApp/assets/teapot2.obj");
+		m_Model.LoadModel("LunarApp/assets/bunny/bunny.obj");
 		//		m_Model.LoadModel("LunarApp/assets/dragon.obj");
 //		m_Model.LoadModel("LunarApp/assets/sphere.obj");
 //		m_Model.LoadModel("LunarApp/assets/shaderBall.obj");

--- a/LunarApp/src/App.cpp
+++ b/LunarApp/src/App.cpp
@@ -261,9 +261,9 @@ public:
 
 	// 1. Create object
 //		 m_Model.LoadModel("LunarApp/assets/teapot2.obj");
-		m_Model.LoadModel("LunarApp/assets/bunny/bunny.obj");
-		//		m_Model.LoadModel("LunarApp/assets/dragon.obj");
-//		m_Model.LoadModel("LunarApp/assets/sphere.obj");
+//		m_Model.LoadModel("LunarApp/assets/bunny/bunny.obj");
+//				m_Model.LoadModel("LunarApp/assets/dragon.obj");
+		m_Model.LoadModel("LunarApp/assets/sphere.obj");
 //		m_Model.LoadModel("LunarApp/assets/shaderBall.obj");
 
 	// 2. Create Texture
@@ -278,7 +278,7 @@ public:
 
 	// 4. Init Camera
 		auto aspectRatio = (float)width / (float)height;
-		m_EditorCamera = Lunar::EditorCamera(45.0f, aspectRatio, 0.1f, 100.0f);
+		m_EditorCamera = Lunar::EditorCamera(45.0f, aspectRatio, 0.01f, 100.0f);
 		const auto p = m_EditorCamera.GetPosition();
 		LOG_INFO("camera pos x{0} y{1} z{2}", p.x, p.y, p.z);
 		const auto l = m_EditorCamera.GetForwardDirection();
@@ -342,6 +342,10 @@ public:
 				shaderProcPtr->SetPickMode(1);
 				shaderProcPtr->SetPickedMeshData(hit.triangle.v0.GetVertex(), hit.triangle.v1.GetVertex(), hit.triangle.v2.GetVertex());
 				LOG_INFO("HIT SUCCESS");
+				auto p = m_EditorCamera.GetPosition();
+				auto k = m_EditorCamera.GetPitch(); auto e = m_EditorCamera.GetYaw();
+				LOG_INFO("camera pos    X{0} Y{1} Z{2}", p.x, p.y, p.z);
+				LOG_INFO("camera angle  Pitch{0} Yaw{1}", k, e);
 				/*
 				LOG_INFO("*********************************************************");
 				LOG_INFO("*             HIT SUCCESS!!                             *");
@@ -370,6 +374,7 @@ public:
 		{
 			// 0. bind frame buffer ( = render target image )
 			m_RasterizationFrameBuffer.Bind();
+
 			glClearColor(0.0f, 0.0f, 0.0f, 1.0f); // 1. Unbind current frame buffer data.
 			glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
 			{
@@ -382,6 +387,8 @@ public:
 
 				if (m_ShowMesh)
 				{
+					glEnable(GL_DEPTH_TEST); // 약간 야매 방식. depth buffer 없이 실시간 검사로 일단 테스트 (임시 방편)
+					glEnable(GL_CULL_FACE); //  enable backface culling
 					m_DisplayMode.BindCurrentShader();
 					const auto shaderProcPtr = m_DisplayMode.GetCurrentShaderPtr();
 					shaderProcPtr->SetUniformEyePos(m_EditorCamera.GetPosition());
@@ -477,6 +484,8 @@ public:
 						// NOTE: Draw a full screen covering triangle for bufferless rendering...
 						// https://trass3r.github.io/coding/2019/09/11/bufferless-rendering.html
 						// https://asliceofrendering.com/scene%20helper/2020/01/05/InfiniteGrid/
+						gridShaderPtr->m_FarClip = m_EditorCamera.GetFarClip();
+						gridShaderPtr->m_NearClip = m_EditorCamera.GetNearClip();
 						gridShaderPtr->Bind();
 						gridShaderPtr->SetUniformProjection(glm::value_ptr(m_EditorCamera.GetProjection()));
 						gridShaderPtr->SetUniformView(glm::value_ptr(m_EditorCamera.GetViewMatrix()));

--- a/LunarApp/src/App.cpp
+++ b/LunarApp/src/App.cpp
@@ -260,8 +260,8 @@ public:
 		m_RasterizationFrameBuffer.Init(width, height); // Init Rasterization buffer
 
 	// 1. Create object
-//		m_Model.LoadModel("LunarApp/assets/teapot2.obj");
-		m_Model.LoadModel("LunarApp/assets/sphere.obj");
+		m_Model.LoadModel("LunarApp/assets/teapot2.obj");
+//		m_Model.LoadModel("LunarApp/assets/sphere.obj");
 //		m_Model.LoadModel("LunarApp/assets/shaderBall.obj");
 
 	// 2. Create Texture

--- a/LunarApp/src/App.cpp
+++ b/LunarApp/src/App.cpp
@@ -261,9 +261,9 @@ public:
 
 	// 1. Create object
 //		 m_Model.LoadModel("LunarApp/assets/teapot2.obj");
-//		m_Model.LoadModel("LunarApp/assets/bunny/bunny.obj");
+		m_Model.LoadModel("LunarApp/assets/bunny/bunny.obj");
 //				m_Model.LoadModel("LunarApp/assets/dragon.obj");
-		m_Model.LoadModel("LunarApp/assets/sphere.obj");
+//		m_Model.LoadModel("LunarApp/assets/sphere.obj");
 //		m_Model.LoadModel("LunarApp/assets/shaderBall.obj");
 
 	// 2. Create Texture

--- a/LunarApp/src/App.cpp
+++ b/LunarApp/src/App.cpp
@@ -260,10 +260,10 @@ public:
 		m_RasterizationFrameBuffer.Init(width, height); // Init Rasterization buffer
 
 	// 1. Create object
-		// m_Model.LoadModel("LunarApp/assets/teapot2.obj");
+		 m_Model.LoadModel("LunarApp/assets/teapot2.obj");
 //		m_Model.LoadModel("LunarApp/assets/bunny/bunny.obj");
 		//		m_Model.LoadModel("LunarApp/assets/dragon.obj");
-		m_Model.LoadModel("LunarApp/assets/sphere.obj");
+//		m_Model.LoadModel("LunarApp/assets/sphere.obj");
 //		m_Model.LoadModel("LunarApp/assets/shaderBall.obj");
 
 	// 2. Create Texture

--- a/LunarApp/src/App.cpp
+++ b/LunarApp/src/App.cpp
@@ -260,8 +260,10 @@ public:
 		m_RasterizationFrameBuffer.Init(width, height); // Init Rasterization buffer
 
 	// 1. Create object
-		m_Model.LoadModel("LunarApp/assets/teapot2.obj");
-//		m_Model.LoadModel("LunarApp/assets/sphere.obj");
+		// m_Model.LoadModel("LunarApp/assets/teapot2.obj");
+//		m_Model.LoadModel("LunarApp/assets/bunny/bunny.obj");
+		//		m_Model.LoadModel("LunarApp/assets/dragon.obj");
+		m_Model.LoadModel("LunarApp/assets/sphere.obj");
 //		m_Model.LoadModel("LunarApp/assets/shaderBall.obj");
 
 	// 2. Create Texture

--- a/LunarApp/src/shaders/DataVisualizer.h
+++ b/LunarApp/src/shaders/DataVisualizer.h
@@ -16,10 +16,10 @@ class DataVisualizer
 {
 public:
 	bool m_ShowNormal = false;
-	bool m_ShowWireframe = false;
-	bool m_ShowPoint = false;
+	bool m_ShowWireframe = true;
+	bool m_ShowPoint = true;
 	bool m_ShowAABB = false;
-	bool m_ShowGrid = false;
+	bool m_ShowGrid = true;
 
 	Lunar::Shader* m_NormalShader = nullptr;
 	Lunar::Shader* m_WireframeShader = nullptr;

--- a/LunarApp/src/shaders/Grid/GridShader.h
+++ b/LunarApp/src/shaders/Grid/GridShader.h
@@ -10,9 +10,14 @@
 class GridShader : public Lunar::Shader
 {
 public:
-	glm::vec4 m_GridColor = glm::vec4(1.0f, 0.0f, 0.0f, 1.0f);
+	glm::vec4 m_GridColor = glm::vec4(0.4f, 0.4f, 0.4f, 1.0f);
+	float m_FarClip = 1000.0f;
+	float m_NearClip = 0.01f;
+
 private:
 	GLint m_GridColorLocation = 0;
+	GLint m_FarLocation = 0;
+	GLint m_NearLocation = 0;
 	GLuint m_DummyVAO = 0; // OpenGL Core는 VAO 0을 오브젝트 없음으로 해석함.
 
 public:
@@ -23,6 +28,8 @@ public:
 		  )
 				  {
 					  m_GridColorLocation = this->_GetUniformLocation("GridColor");
+					  m_FarLocation = this->_GetUniformLocation("FarClip"); // for gid fade-out
+					  m_NearLocation = this->_GetUniformLocation("NearClip"); // for gid fade-out
 					  glGenVertexArrays(1, &m_DummyVAO);
 				  };
 
@@ -32,6 +39,8 @@ private:
 	 {
 		 glEnable(GL_PROGRAM_POINT_SIZE);
 		 glUniform4fv(m_GridColorLocation, 1, glm::value_ptr(m_GridColor));
+		 glUniform1f(m_FarLocation, m_FarClip);
+		 glUniform1f(m_NearLocation, m_NearClip);
 	 };
 	 void OnUnbind() override
 	 {

--- a/LunarApp/src/shaders/Grid/fragment_shader.glsl
+++ b/LunarApp/src/shaders/Grid/fragment_shader.glsl
@@ -1,10 +1,76 @@
 #version 330 core // version is 3.3.0
 
+in vec3 nearPoint; // nearPoint calculated in vertex shader
+in vec3 farPoint; // farPoint calculated int vertex shader
+in mat4 fragView;
+in mat4 fragProj;
+
 out vec4 FragmentColor; // output data
 
 uniform vec4 GridColor;
+uniform float NearClip;
+uniform float FarClip;
+
+float computeLinearDepth(vec3 pos) {
+    vec4 clip_space_pos = fragProj * fragView * vec4(pos.xyz, 1.0);
+    float clip_space_depth = (clip_space_pos.z / clip_space_pos.w) * 2.0 - 1.0; // put back between -1 and 1
+    float linearDepth = (2.0 * NearClip * FarClip) / (FarClip + NearClip - clip_space_depth * (FarClip - NearClip)); // get linear value between 0.01 and 100
+    return linearDepth / FarClip; // normalize
+}
+
+vec4 grid(vec3 fragPos3D, float scale, bool drawAxis) {
+    vec2 coord = fragPos3D.xz * scale;
+    vec2 derivative = fwidth(coord);
+    vec2 grid = abs(fract(coord - 0.5) - 0.5) / derivative;
+    float line = min(grid.x, grid.y);
+    float minimumz = min(derivative.y, 1);
+    float minimumx = min(derivative.x, 1);
+    float LINE_WIDTH = 0.2f;
+
+    // z axis
+    if ((fragPos3D.x > LINE_WIDTH * (-minimumx)) && (fragPos3D.x < LINE_WIDTH * minimumx))
+    {
+        return vec4(0.0, 0.0, 1.0, 1.0 - min(line, 1.0));
+    }
+    // x axis
+    else if ((fragPos3D.z > LINE_WIDTH * (-minimumz)) && (fragPos3D.z < LINE_WIDTH * minimumz))
+    {
+        return vec4(1.0, 0.0, 0.0, 1.0 - min(line, 1.0));
+    }
+    else
+    {
+        float k = 1.0 - min(line, 1.0); // k <= 0 일 경우, 그리드 선 외의 부분.
+        if (k > 0.5) { // line 두께 0.5
+            vec4 color = vec4(GridColor.xyz, 1.0 - min(line, 1.0));
+            return color;
+        } else {
+            discard;
+        }
+    }
+}
+
+float computeDepth(vec3 pos) {
+    vec4 clip_space_pos = fragProj * fragView * vec4(pos.xyz, 1.0);
+    return (clip_space_pos.z / clip_space_pos.w);
+}
 
 void main()
 {
-    FragmentColor = GridColor;
+    float t = -nearPoint.y / (farPoint.y - nearPoint.y);
+    vec3 fragPos3D = nearPoint + t * (farPoint - nearPoint);
+
+    // https://stackoverflow.com/questions/72791713/issues-with-infinite-grid-in-opengl-4-5-with-glsl
+    gl_FragDepth = ((gl_DepthRange.diff * computeDepth(fragPos3D)) + gl_DepthRange.near + gl_DepthRange.far) / 2.0;
+
+    float linearDepth = computeLinearDepth(fragPos3D);
+    float fading = max((1.0f - linearDepth), 0.0f); // 0.0 ~ 1.0f
+    float fadingPow = pow(fading, 8.0f);
+
+    if (fading < 0.2f) {
+        FragmentColor = vec4(0.0f, 0.0f, 0.0f, 1.0f);
+    } else {
+//        FragmentColor = grid(fragPos3D, 1, true) * float(t > 0);
+        FragmentColor = (grid(fragPos3D, 10, true) + grid(fragPos3D, 1, true)) * float(t > 0); // adding multiple resolution for the grid
+        FragmentColor *= fadingPow;
+    }
 }

--- a/LunarApp/src/shaders/Grid/vertex_shader.glsl
+++ b/LunarApp/src/shaders/Grid/vertex_shader.glsl
@@ -4,14 +4,34 @@ layout (location = 0) in vec3 in_position; // X Y Z
 uniform mat4 Projection;
 uniform mat4 View;
 
+out mat4 fragProj;
+out mat4 fragView;
+out vec3 nearPoint;
+out vec3 farPoint;
+
+// NOTE: Infinite Grid
+// https://asliceofrendering.com/scene%20helper/2020/01/05/InfiniteGrid/
+
 // Grid position are in xy clipped space
 vec3 gridPlane[6] = vec3[](
     vec3(-1, -1, 0), vec3(1, 1, 0), vec3(-1, 1, 0),
     vec3(-1, -1, 0), vec3(1, -1, 0), vec3(1, 1, 0)
 );
 
+vec3 UnprojectPoint(float x, float y, float z, mat4 view, mat4 projection) {
+    mat4 viewInv = inverse(view);
+    mat4 projInv = inverse(projection);
+    vec4 unprojectedPoint =  viewInv * projInv * vec4(x, y, z, 1.0);
+    return unprojectedPoint.xyz / unprojectedPoint.w;
+}
+
 void main(void)
 {
-    gl_Position = Projection * View * vec4(gridPlane[gl_VertexID].xyz, 1.0);
-    gl_PointSize = 10.0f;
+    fragProj = Projection;
+    fragView = View;
+    // gl_VertexID = vertex count (6 draw call) --> from "glDrawArrays(GL_TRIANGLES, 0, 6)"
+    vec3 p = gridPlane[gl_VertexID].xyz;
+    nearPoint = UnprojectPoint(p.x, p.y, 0.0, View, Projection).xyz; // unprojecting on the near plane
+    farPoint = UnprojectPoint(p.x, p.y, 1.0, View, Projection).xyz; // unprojecting on the far plane
+    gl_Position = vec4(p, 1.0); // using directly the clipped coordinates
 }

--- a/LunarApp/src/shaders/Point/PointShader.h
+++ b/LunarApp/src/shaders/Point/PointShader.h
@@ -10,7 +10,7 @@
 class PointShader : public Lunar::Shader
 {
 public:
-	glm::vec4 m_PointColor = glm::vec4(0.0f, 0.0f, 1.0f, 1.0f);
+	glm::vec4 m_PointColor = glm::vec4(1.0f, 1.0f, 1.0f, 1.0f);
 private:
 	GLint m_PointColorLocation = 0;
 public:

--- a/LunarApp/src/shaders/Wireframe/WireframeShader.h
+++ b/LunarApp/src/shaders/Wireframe/WireframeShader.h
@@ -10,7 +10,7 @@
 class WireframeShader : public Lunar::Shader
 {
 public:
-	glm::vec4 m_WireframeColor = glm::vec4(1.0f, 0.0f, 0.0f, 1.0f);
+	glm::vec4 m_WireframeColor = glm::vec4(0.6f, 0.6f, 0.6f, 1.0f);
 private:
 	GLint m_WireframeColorLocation = 0;
 public:

--- a/Readme.md
+++ b/Readme.md
@@ -1,6 +1,8 @@
 ## Obj file viewer 
 ![image](https://github.com/kimminkyeu/MiniBlender/assets/60287070/eb0c17c9-8fd3-43de-923e-be2e1da90362)
 
+sample assets from
+https://casual-effects.com/data/
 
 ## Compile & Run
 this project is for Linux, MacOS. (Windows is currently not supported)


### PR DESCRIPTION
기존 방식 : vertex centroid 기준으로 SAH를 각각 계산
- 문제점 : split이 많아지는 만큼 트리의 퀄리티는 좋아지지만, 빌드타임이 오래걸림

개선안 : 명시적으로 N개의 Bin을 생성하여, 각 구간에 해당하는 vertex들을 uniform split 방식으로 나눔.
- 이 경우 트리의 깊이가 기존방식보다 낮아짐 (BBox 개수 감소) --> 빌드 타임 개선 